### PR TITLE
Initialize SDL2 outside of Video

### DIFF
--- a/source/app.c
+++ b/source/app.c
@@ -8,6 +8,11 @@
 App app;
 
 void App_Init(void) {
+	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+		fprintf(stderr, "Failed to initialise SDL2: %s\n", SDL_GetError());
+		exit(1);
+	}
+
 	Video_Init();
 
 	app.running = true;
@@ -30,6 +35,7 @@ void App_Free(void) {
 	Map_Free();
 	Text_FreeFont(&app.font);
 	Video_Free();
+	SDL_Quit();
 }
 
 void App_Update(void) {

--- a/source/app.c
+++ b/source/app.c
@@ -8,7 +8,7 @@
 App app;
 
 void App_Init(void) {
-	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+	if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
 		fprintf(stderr, "Failed to initialise SDL2: %s\n", SDL_GetError());
 		exit(1);
 	}

--- a/source/video.c
+++ b/source/video.c
@@ -5,11 +5,6 @@
 Video video;
 
 void Video_Init(void) {
-	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-		fprintf(stderr, "Failed to initialise SDL2: %s\n", SDL_GetError());
-		exit(1);
-	}
-
 	assert(SDL_GL_SetAttribute(
 		SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY
 	) == 0);
@@ -45,5 +40,4 @@ void Video_Init(void) {
 void Video_Free(void) {
 	Backend_Free();
 	SDL_DestroyWindow(video.window);
-	SDL_Quit();
 }


### PR DESCRIPTION
Move initialization of SDL2 outside of Video into App, because it is also responsible for initializing other things (currently events, in the future possibly audio too).