### PR TITLE
Fixed some parser bugs and improved echo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ override CFLAGS += -DAE_BACKEND_GL11
 
 ifeq ($(BUILD),release)
 	override CFLAGS += -O3
+	#override CPPFLAGS += -NDEBUG
 else
-	override CFLAGS += -g
+	override CFLAGS += -Og -g
 	ifeq ($(ASAN),y)
-		override CFLAGS += -fsanitize=address
+		override CFLAGS += -fno-omit-frame-pointer -fsanitize=address
+		override LDFLAGS += -fsanitize=address
 	endif
 endif
 

--- a/source/commands.c
+++ b/source/commands.c
@@ -94,15 +94,16 @@ static void Command_Cat(size_t argc, char** argv) {
 }
 
 static void Command_Echo(size_t argc, char** argv) {
-	char* argvIt = argv[0];
-	for (size_t i = 0; i < argc; ++ argvIt) {
-		if (*argvIt == 0) {
-			*argvIt = ' ';
-			++ i;
-		}
+	for (size_t i = 1; i < argc; ++ i) {
+		argv[i][-1] = ' ';
 	}
 
-	Log("%s", argv[0]);
+	if (argc) {
+		Log("%s", argv[0]);
+	}
+	else {
+		Log("");
+	}
 }
 
 void Commands_Init(void) {

--- a/source/map.c
+++ b/source/map.c
@@ -183,6 +183,8 @@ bool Map_LoadFile(const char* path) {
 		map.sectors[i].ceilingTexture = Resources_GetRes(stringTable[ceilTexture]);
 	}
 
+	fclose(file);
+
 	Log("Loaded map");
 	camera.sector = &map.sectors[0];
 
@@ -257,6 +259,8 @@ bool Map_SaveFile(const char* path) {
 	}
 
 	FreeStrArray(stringTable);
+
+	fclose(file);
 
 	Log("Saved map '%s'", map.name);
 

--- a/source/model.c
+++ b/source/model.c
@@ -54,6 +54,8 @@ void Model_Load(Model* model, const char* path) {
 		model->faces[i].colour.g           = File_Read8(file);
 		model->faces[i].colour.b           = File_Read8(file);
 	}
+
+    fclose(file);
 }
 
 void Model_Free(Model* model) {


### PR DESCRIPTION
- Fixed a command parsing bug where argc is 1 on empty strings but 0 when given whitespace
- Fixed a command parsing bug where an extra empty arg was added if the command ended in whitespace
- Made an exception to not evaluate the command if the parser emits an argc of 0
- Optimized the 'echo' command
- Changed the 'Invalid command' message to 'Bad syntax' which better matches the error
- Fixed a memory leak in RunCommand (return without freeing the parser output after successfully running a command)